### PR TITLE
change: remove optimistic assumption in _getPeer

### DIFF
--- a/contracts/OmniXMultisender.sol
+++ b/contracts/OmniXMultisender.sol
@@ -320,7 +320,7 @@ contract OmniXMultisender is Initializable, Clone {
 
     function _getPeer(uint32 _dstEid) internal view returns (bytes32) {
         bytes32 trustedRemote = peers[_dstEid];
-        if (trustedRemote == 0) return bytes32(uint256(uint160(address(this))));
+        if (trustedRemote == 0) revert();
         else return trustedRemote;
     }
 


### PR DESCRIPTION
This PR removes the optimistic peer assumption in the multisender. Optimistic peer assumption is nice from a developer standpoint because it saves us setPeers transactions, but since we are running an explicit security and config setup on every chain anyways, for safety purposes we will revert if setPeers have not been called for a deid explicitly.

Addresses issue [#3](https://github.com/cantinasec/omni-x-review/issues/3)