### PR TITLE
change: add a array length check in _sendDeposits

### DIFF
--- a/contracts/OmniXMultisender.sol
+++ b/contracts/OmniXMultisender.sol
@@ -279,6 +279,11 @@ contract OmniXMultisender is Initializable, Clone {
         uint128[] calldata amounts,
         address to
     ) internal virtual {
+        require(
+            dstEids.length == amounts.length,
+            "OmniXMultisender._sendDeposits: Input arrays must have the same length"
+        );
+        
         uint256 fee;
         uint256 omniBalance =
             omniNft() == address(0) ? 0 : SafeTransferLib.balanceOf(omniNft(), msg.sender);


### PR DESCRIPTION
This check is similar to the one in #3, it helps to make sure that arrays passed in _sendDeposits function are the same length to prevent unintended behavior and errors.

Addresses the same issue as the one tagged in [#16](https://github.com/cantinasec/omni-x-review/issues/16)