### PR TITLE
change: change OmniXMultisender interface and import names to proper IOmniXMultisender

### DIFF
--- a/contracts/OmniXMultisenderFactory.sol
+++ b/contracts/OmniXMultisenderFactory.sol
@@ -7,7 +7,7 @@ import { SafeTransferLib } from "solady/src/utils/SafeTransferLib.sol";
 
 import { Ownable } from "solady/src/auth/Ownable.sol";
 
-interface OmniXMultisender {
+interface IOmniXMultisender {
     function initialize() external;
     function setPeers(uint32[] calldata remoteEids, bytes32[] calldata remoteAddresses)
         external;
@@ -53,7 +53,7 @@ contract OmniXMultisenderFactory is Ownable {
             abi.encodePacked(endpoint, address(this), omniNft, defaultGasLimit)
         );
 
-        OmniXMultisender(instance).initialize();
+        IOmniXMultisender(instance).initialize();
     }
 
     function setPeers(
@@ -61,7 +61,7 @@ contract OmniXMultisenderFactory is Ownable {
         uint32[] calldata remoteEids,
         bytes32[] calldata remoteAddresses
     ) external virtual onlyOwner {
-        OmniXMultisender(instance).setPeers(remoteEids, remoteAddresses);
+        IOmniXMultisender(instance).setPeers(remoteEids, remoteAddresses);
     }
 
     function setGasLimit(
@@ -69,11 +69,11 @@ contract OmniXMultisenderFactory is Ownable {
         uint32[] calldata remoteEids,
         uint128[] calldata gasLimits
     ) external virtual onlyOwner {
-        OmniXMultisender(instance).setGasLimit(remoteEids, gasLimits);
+        IOmniXMultisender(instance).setGasLimit(remoteEids, gasLimits);
     }
 
     function setDelegate(address instance, address delegate) external virtual onlyOwner {
-        OmniXMultisender(instance).setDelegate(delegate);
+        IOmniXMultisender(instance).setDelegate(delegate);
     }
 
     function setUlnConfigs(
@@ -83,7 +83,7 @@ contract OmniXMultisenderFactory is Ownable {
         uint32[] calldata eids,
         address dvn
     ) external virtual onlyOwner {
-        OmniXMultisender(instance).setUlnConfigs(lib, confirmations, eids, dvn);
+        IOmniXMultisender(instance).setUlnConfigs(lib, confirmations, eids, dvn);
     }
 
     function withdraw(address token, address to) external virtual onlyOwner {


### PR DESCRIPTION
This PR renames OmniXMultisender interface in the factory and all its mentions to IOmniXMultisender, as it should be according to naming conventions.

Addresses issue [#12](https://github.com/cantinasec/omni-x-review/issues/12)