### PR TITLE
change: add a verification check for setUlnConfigs input

### DIFF
--- a/contracts/OmniXMultisender.sol
+++ b/contracts/OmniXMultisender.sol
@@ -175,6 +175,9 @@ contract OmniXMultisender is Initializable, Clone {
         uint32[] calldata eids,
         address dvn
     ) external virtual onlyFactory {
+        if (lib == address(0) || dvn == address(0))
+            revert("OmniXMultisender.setUlnConfigs: Either lib or dvn passed address is 0.");
+
         SetConfigParam[] memory configs = new SetConfigParam[](eids.length);
 
         for (uint256 i; i < eids.length;) {


### PR DESCRIPTION
This PR adds a verification check that reverts if either a library or a dvn address that is being passed to setUlnConfigs function is 0

Addresses issue [#17](https://github.com/cantinasec/omni-x-review/issues/17)