### PR TITLE
Change optimizer runs

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -47,7 +47,7 @@ const config: HardhatUserConfig = {
                 settings: {
                     optimizer: {
                         enabled: true,
-                        runs: 2147483647,
+                        runs: 2147483646,
                     },
                 },
             },


### PR DESCRIPTION
This PR increases the number of optimizer runs from 200 to max(uint32) - 1. This should make the final code more optimized towards the runtime vs the deployment costs.

Addresses issue [#21](https://github.com/cantinasec/omni-x-review/issues/21) 